### PR TITLE
go get fails: github.com/xenolf/lego was moved to github.com/go-acme/lego

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/xenolf/lego/certificate"
+	"github.com/go-acme/lego/certificate"
 )
 
 // parsePEMBundle parses a certificate bundle from top to bottom and returns

--- a/client.go
+++ b/client.go
@@ -13,13 +13,13 @@ import (
 	"log"
 	"strings"
 
-	"github.com/xenolf/lego/providers/dns"
+	"github.com/go-acme/lego/providers/dns"
 
-	"github.com/xenolf/lego/certcrypto"
-	"github.com/xenolf/lego/challenge/http01"
-	"github.com/xenolf/lego/challenge/tlsalpn01"
-	"github.com/xenolf/lego/lego"
-	"github.com/xenolf/lego/registration"
+	"github.com/go-acme/lego/certcrypto"
+	"github.com/go-acme/lego/challenge/http01"
+	"github.com/go-acme/lego/challenge/tlsalpn01"
+	"github.com/go-acme/lego/lego"
+	"github.com/go-acme/lego/registration"
 )
 
 /*

--- a/cr.go
+++ b/cr.go
@@ -9,7 +9,7 @@
 package simplecert
 
 import (
-	"github.com/xenolf/lego/certificate"
+	"github.com/go-acme/lego/certificate"
 )
 
 // CR represents an ACME Certificate Resource

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -12,7 +12,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/gosticks/simplecert"
+	"github.com/foomo/simplecert"
 )
 
 func main() {

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -12,7 +12,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/foomo/simplecert"
+	"github.com/gosticks/simplecert"
 )
 
 func main() {

--- a/renew.go
+++ b/renew.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/xenolf/lego/certificate"
+	"github.com/go-acme/lego/certificate"
 )
 
 func renew(cert *certificate.Resource) error {

--- a/simplecert.go
+++ b/simplecert.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/xenolf/lego/certificate"
+	"github.com/go-acme/lego/certificate"
 )
 
 const (

--- a/user.go
+++ b/user.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"path/filepath"
 
-	"github.com/xenolf/lego/registration"
+	"github.com/go-acme/lego/registration"
 )
 
 const sslUserFileName = "SSLUser.json"


### PR DESCRIPTION
When trying to run go get -v 'github.com/foomo/simplecert the following error occurs:

`
../../../foomo/simplecert/client.go:32:27: cannot use &u (type *SSLUser) as type "github.com/go-acme/lego/registration".User in argument to lego.NewConfig:
	*SSLUser does not implement "github.com/go-acme/lego/registration".User (wrong type for GetRegistration method)
		have GetRegistration() *"github.com/xenolf/lego/registration".Resource
		want GetRegistration() *"github.com/go-acme/lego/registration".Resource
`

It seems **github.com/xenolf/lego** was moved to  **github.com/go-acme/lego/**. I changed all imports of the package which solved the issue for me. 