### PR TITLE
allow to override dns resolvers if needed

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/go-acme/lego/v3/challenge/dns01"
 	"github.com/go-acme/lego/v3/challenge/tlsalpn01"
 
 	"github.com/go-acme/lego/v3/certcrypto"
@@ -26,7 +27,7 @@ import (
  *	ACMEClient
  */
 
-func createClient(u SSLUser) (lego.Client, error) {
+func createClient(u SSLUser, dnsServers []string) (lego.Client, error) {
 
 	// create lego config
 	config := lego.NewConfig(&u)
@@ -51,7 +52,7 @@ func createClient(u SSLUser) (lego.Client, error) {
 			return *client, fmt.Errorf("simplecert: setting DNS provider specified in config: %s", err)
 		}
 
-		err = client.Challenge.SetDNS01Provider(p)
+		err = client.Challenge.SetDNS01Provider(p, dns01.CondOption((len(dnsServers) > 0), dns01.AddRecursiveNameservers(dns01.ParseNameservers(dnsServers))))
 		if err != nil {
 			return *client, fmt.Errorf("simplecert: setting DNS challenge provider failed: %s", err)
 		}

--- a/config.go
+++ b/config.go
@@ -41,6 +41,7 @@ var Default = &Config{
 	DNSProvider:   "",
 	Local:         false,
 	UpdateHosts:   true,
+	DNSServers:    []string{},
 }
 
 // Config allows configuration of simplecert
@@ -70,6 +71,9 @@ type Config struct {
 
 	// Domains for which to obtain the certificate
 	Domains []string
+
+	// DNSServers overrides the dns resolvers to use for a dns challenge, this is handy if you have a split dns.
+	DNSServers []string
 
 	// Path of the CacheDir
 	CacheDir string

--- a/renew.go
+++ b/renew.go
@@ -54,7 +54,7 @@ func renew(cert *certificate.Resource) error {
 		}
 
 		// get ACME Client
-		client, err := createClient(u)
+		client, err := createClient(u, c.DNSServers)
 		if err != nil {
 			return fmt.Errorf("simplecert: failed to create lego.Client: %s", err)
 		}

--- a/simplecert.go
+++ b/simplecert.go
@@ -140,7 +140,7 @@ func Init(cfg *Config, cleanup func()) (*CertReloader, error) {
 			// since a renewal might result in receiving a SIGHUP for triggering the reload
 			// the goroutine for handling the signal and taking action is started when creating the reloader
 			certReloader, errReloader = NewCertReloader(certFilePath, keyFilePath, logFile, cleanup)
-			cert = getACMECertResource(cr)
+			cert                      = getACMECertResource(cr)
 		)
 
 		// renew cert if necessary
@@ -167,7 +167,7 @@ obtainNewCert:
 	}
 
 	// get ACME Client
-	client, err := createClient(u)
+	client, err := createClient(u, c.DNSServers)
 	if err != nil {
 		log.Fatal("[FATAL] failed to create lego.Client: ", err)
 	}

--- a/status.go
+++ b/status.go
@@ -12,7 +12,6 @@ type CertStatus struct {
 	Domains     []string
 	RenewBefore int
 	Expires     int
-	DnsServers  []string
 }
 
 // Status can be used to check the validity status of the certificate

--- a/status.go
+++ b/status.go
@@ -9,9 +9,10 @@ import (
 )
 
 type CertStatus struct {
-	Domains []string
+	Domains     []string
 	RenewBefore int
-	Expires int
+	Expires     int
+	DnsServers  []string
 }
 
 // Status can be used to check the validity status of the certificate
@@ -80,8 +81,8 @@ func Status() *CertStatus {
 	// Calculate TimeLeft
 	timeLeft := x509Cert.NotAfter.Sub(time.Now().UTC())
 	return &CertStatus{
-		Domains: x509Cert.DNSNames,
-		Expires: int(timeLeft.Hours()),
+		Domains:     x509Cert.DNSNames,
+		Expires:     int(timeLeft.Hours()),
 		RenewBefore: c.RenewBefore,
 	}
 }


### PR DESCRIPTION
Optionally change the DNS servers used when using DNS challenge (instead of the system default).
This can be helpful in split DNS situations where the internal DNS should not be used to verify.